### PR TITLE
fix: run full build for prepare script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
           package-name: '@amplience/dc-integration-stylitics'
-          release-as: 0.1.0
           prerelease: true
 
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-dist": "run-p build-dist:*",
     "build-dist:dev": "NODE_ENV=development webpack",
     "build-dist:prod": "NODE_ENV=production webpack",
-    "prepare": "eslint && npm run clean && tsc",
+    "prepare": "eslint && npm run clean && npm run build",
     "test": "jest --silent --verbose",
     "version:patch": "standard-version --release-as patch",
     "version:minor": "standard-version --release-as minor",


### PR DESCRIPTION
This should fix the issue where `dist/` is missing from the NPM package. Also, unlocks the release-please version.